### PR TITLE
article-about action unscoped

### DIFF
--- a/backend/app/controllers/api/v1/articles_controller.rb
+++ b/backend/app/controllers/api/v1/articles_controller.rb
@@ -43,10 +43,12 @@ class Api::V1::ArticlesController < ApplicationController
     end
 
     # aboutページ用の3件のarticleを取得
+    # いいねの多い記事3件を取得 ※ default_scopeでいいねの多い順が正しく反映されない為、ここだけスキップするunscoped
     def article_about
-        likes_id = Article.joins(:likes)
-                            .group(:article_id)
-                            .order('COUNT(likes.article_id) DESC')
+        likes_id = Article.unscoped
+                            .joins(:likes)
+                            .group('articles.id')
+                            .order('COUNT(likes.id) DESC')
                             .limit(3)
                             .pluck(:id)
         articles = Article.includes(:user, :likes, :level_list, :tag_list, :comments)


### PR DESCRIPTION
下記を実装

- article-about アクションを修正
　default-scopeで想定通りの順番にならなかったので、unscopedを実施